### PR TITLE
feat: alias domain to deployment

### DIFF
--- a/.github/workflows/example-angular.yml
+++ b/.github/workflows/example-angular.yml
@@ -22,6 +22,7 @@ jobs:
           cd example/angular
           npm ci
           npx ng build --prod
+
       - uses: ./
         id: vercel-action-staging
         if: github.event_name == 'pull_request'
@@ -31,6 +32,9 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_ANGULAR }}
           working-directory: example/angular/dist/angular
+          alias-domains: |
+            staging.angular.vercel-action.amond.dev
+            pr-{{PR_NUMBER}}.angular.vercel-action.amond.dev
       - uses: ./
         id: vercel-action-production
         if: github.event_name == 'push'

--- a/.github/workflows/example-static.yml
+++ b/.github/workflows/example-static.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - feature/*
   pull_request:
     branches:
       - master
@@ -21,6 +22,20 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_STATIC }}
           working-directory: example/static
+          alias-domains: |
+            staging.static.vercel-action.amond.dev
+            pr-{{PR_NUMBER}}.static.vercel-action.amond.dev
+      - name: production or not
+        id: prod_or_not
+        run: |
+          if [$REF == 'refs/heads/master']
+          then
+              echo "::set-output name=vercel-args::--prod"
+          else
+              echo "::set-output name=vercel-args::"
+          fi
+        env:
+          REF: ${{ github.ref }}
       - uses: ./
         id: now-deployment-production
         if: github.event_name == 'push'
@@ -29,5 +44,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_STATIC }}
-          vercel-args: '--prod'
+          vercel-args: ${{ steps.prod_or_not.outputs.vercel-args }}
           working-directory: example/static
+          alias-domains: |
+            {{BRANCH}}.static.vercel-action.amond.dev

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This action make a Vercel deployment with github actions.
 | vercel-args       |    [ ]   |         | This is optional args for `vercel` cli. Example: `--prod`                                            |
 | working-directory |    [ ]   |         | the working directory                                                                             |
 | scope             |    [ ]   |         | If you are working in a team scope, you should set this value to your `team ID`.           
+| alias-domains     |    [ ]   |         | You can assign a domain to this deployment. Please note that this domain must have been configured in the project. You can use pull request number via `{{PR_NUMBER}}` and branch via `{{BRANCH}}`.         
 
 ## Outputs
 
@@ -61,7 +62,7 @@ The url of deployment preview.
 
 The name of deployment name.
 
-## Example Usage
+## How To Use
 
 ### Disable Vercel for GitHub
 
@@ -174,6 +175,60 @@ How to add Basic Authentication to a Vercel deployment
 See [.github/workflows/example-express-basic-auth.yml](.github/workflows/example-express-basic-auth.yml)
 
 [source code](https://github.com/amondnet/vercel-action/tree/master/example/express-basic-auth)
+
+### Alias Domains
+
+You can assign a domain to this deployment. Please note that this domain must have been [configured](https://vercel.com/docs/v2/custom-domains#adding-a-domain) in the project.
+
+If you want to assign domain to branch or pr, you should add [Wildcard Domain](https://vercel.com/docs/v2/custom-domains#wildcard-domains).
+
+You can use pull request number via `{{PR_NUMBER}}` and branch via `{{BRANCH}}`
+
+#### Example 
+
+Wildcard Domains : *.angular.vercel-action.amond.dev
+
+*Per Pull Request*
+
+https://pr-{{PR_NUMBER}}.angular.vercel-action.amond.dev
+
+- PR-1 -> https://pr-1.angular.vercel-action.amond.dev
+- PR-2 -> https://pr-2.angular.vercel-action.amond.dev
+
+*Per Branch*
+
+https://{{BRANCH}}.angular.vercel-action.amond.dev
+
+- develop -> https://develop.angular.vercel-action.amond.dev
+- master -> https://master.angular.vercel-action.amond.dev
+- master -> https://master.angular.vercel-action.amond.dev
+
+
+
+See [.github/workflows/example-angular.yml](/.github/workflows/example-angular.yml) 
+
+```yaml
+name: deploy website
+on: [pull_request]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: amondnet/vercel-action@v19
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
+          github-token: ${{ secrets.GITHUB_TOKEN }} #Optional 
+          vercel-args: '--prod' #Optional
+          vercel-org-id: ${{ secrets.ORG_ID}}  #Required
+          vercel-project-id: ${{ secrets.PROJECT_ID}} #Required 
+          working-directory: ./sub-directory #Your Working Directory, Optional
+          alias-domains: | #Optional
+            staging.angular.vercel-action.amond.dev
+            pr-{{PR_NUMBER}}.angular.vercel-action.amond.dev
+```
+
+
 
 ## Migration from v2
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     required: false
     description: 'Vercel CLI 17+, ❗️  The `name` property in vercel.json is deprecated (https://zeit.ink/5F)'
     deprecationMessage: 'Zeit is now Vercel. Use "vercel-org-id" instead.'
+  alias-domains:
+    required: false
+    description: 'You can assign a domain to this deployment. Please note that this domain must have been configured in the project. You can use pull request number via `{{PR_NUMBER}}` and branch via `{{BRANCH}}`'
+    default: ''
 
 outputs:
   preview-url:

--- a/dist/index.js
+++ b/dist/index.js
@@ -21855,9 +21855,11 @@ const aliasDomains = core
   .filter(x => x !== '')
   .map(s => {
     let url = s;
-    let branch = context.ref.replace('/', '-');
+    let branch = context.ref.replace('refs/heads/', '').replace(/\//g, '-');
     if (context.eventName === 'pull_request') {
-      branch = context.payload.pull_request.head.ref.replace('/', '-');
+      branch = context.payload.pull_request.head.ref
+        .replace('refs/heads/', '')
+        .replace(/\//g, '-');
       url = url.replace(prNumberRegExp, context.issue.number.toString());
     }
     url = url.replace(branchRegExp, branch);

--- a/dist/index.js
+++ b/dist/index.js
@@ -22015,12 +22015,21 @@ async function createCommentOnCommit(
     `Deploy preview for _${deploymentName}_ ready!`,
   );
 
+  let previewUrl = deploymentUrl;
+  if (aliasDomains.length) {
+    aliasDomains.forEach(domain => {
+      previewUrl += `\nhttps://${domain}`;
+    });
+  }
+
   const commentBody = stripIndents`
     Deploy preview for _${deploymentName}_ ready!
 
-    Built with commit ${deploymentCommit}
-
-    ${deploymentUrl}
+    ✅ Preview
+    ${previewUrl}
+    
+    Built with commit ${deploymentCommit}.
+    This pull request is being automatically deployed with [vercel-action](https://github.com/marketplace/actions/vercel-action)
   `;
 
   if (commentId) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -21840,12 +21840,30 @@ const githubToken = core.getInput('github-token');
 const githubComment = core.getInput('github-comment') === 'true';
 const workingDirectory = core.getInput('working-directory');
 
+const prNumberRegExp = /{{\s*PR_NUMBER\s*}}/g;
+const branchRegExp = /{{\s*BRANCH\s*}}/g;
+
 // Vercel
 const vercelToken = core.getInput('vercel-token', { required: true });
 const vercelArgs = core.getInput('vercel-args');
 const vercelOrgId = core.getInput('vercel-org-id');
 const vercelProjectId = core.getInput('vercel-project-id');
 const vercelScope = core.getInput('scope');
+const aliasDomains = core
+  .getInput('alias-domains')
+  .split('\n')
+  .filter(x => x !== '')
+  .map(s => {
+    let url = s;
+    let branch = context.ref.replace('/', '-');
+    if (context.eventName === 'pull_request') {
+      branch = context.payload.pull_request.head.ref.replace('/', '-');
+      url = url.replace(prNumberRegExp, context.issue.number.toString());
+    }
+    url = url.replace(branchRegExp, branch);
+
+    return url;
+  });
 
 let octokit;
 if (githubToken) {
@@ -22032,13 +22050,20 @@ async function createCommentOnPullRequest(
     `Deploy preview for _${deploymentName}_ ready!`,
   );
 
+  let previewUrl = deploymentUrl;
+  if (aliasDomains.length) {
+    aliasDomains.forEach(domain => {
+      previewUrl += `\nhttps://${domain}`;
+    });
+  }
+
   const commentBody = stripIndents`
     Deploy preview for _${deploymentName}_ ready!
 
-    Built with commit ${deploymentCommit}
-
-    ✅ Preview: ${deploymentUrl}
-
+    ✅ Preview
+    ${previewUrl}
+    
+    Built with commit ${deploymentCommit}.
     This pull request is being automatically deployed with [vercel-action](https://github.com/marketplace/actions/vercel-action)
   `;
 
@@ -22055,6 +22080,23 @@ async function createCommentOnPullRequest(
       body: commentBody,
     });
   }
+}
+
+async function aliasDomainsToDeployment(deploymentUrl) {
+  if (!deploymentUrl) {
+    core.error('deployment url is null');
+  }
+  const promises = aliasDomains.map(domain => {
+    return exec.exec('npx', [
+      'vercel',
+      'alias',
+      '-t',
+      vercelToken,
+      deploymentUrl,
+      domain,
+    ]);
+  });
+  await Promise.all(promises);
 }
 
 async function run() {
@@ -22107,6 +22149,11 @@ async function run() {
     core.setOutput('preview-name', deploymentName);
   } else {
     core.warning('get preview-name error');
+  }
+
+  if (aliasDomains.length) {
+    core.info('alias domains to this deployment');
+    await aliasDomainsToDeployment(deploymentUrl);
   }
 
   if (githubComment && githubToken) {

--- a/index.js
+++ b/index.js
@@ -10,12 +10,30 @@ const githubToken = core.getInput('github-token');
 const githubComment = core.getInput('github-comment') === 'true';
 const workingDirectory = core.getInput('working-directory');
 
+const prNumberRegExp = /{{\s*PR_NUMBER\s*}}/g;
+const branchRegExp = /{{\s*BRANCH\s*}}/g;
+
 // Vercel
 const vercelToken = core.getInput('vercel-token', { required: true });
 const vercelArgs = core.getInput('vercel-args');
 const vercelOrgId = core.getInput('vercel-org-id');
 const vercelProjectId = core.getInput('vercel-project-id');
 const vercelScope = core.getInput('scope');
+const aliasDomains = core
+  .getInput('alias-domains')
+  .split('\n')
+  .filter(x => x !== '')
+  .map(s => {
+    let url = s;
+    let branch = context.ref.replace('/', '-');
+    if (context.eventName === 'pull_request') {
+      branch = context.payload.pull_request.head.ref.replace('/', '-');
+      url = url.replace(prNumberRegExp, context.issue.number.toString());
+    }
+    url = url.replace(branchRegExp, branch);
+
+    return url;
+  });
 
 let octokit;
 if (githubToken) {
@@ -202,13 +220,20 @@ async function createCommentOnPullRequest(
     `Deploy preview for _${deploymentName}_ ready!`,
   );
 
+  let previewUrl = deploymentUrl;
+  if (aliasDomains.length) {
+    aliasDomains.forEach(domain => {
+      previewUrl += `\nhttps://${domain}`;
+    });
+  }
+
   const commentBody = stripIndents`
     Deploy preview for _${deploymentName}_ ready!
 
-    Built with commit ${deploymentCommit}
-
-    ✅ Preview: ${deploymentUrl}
-
+    ✅ Preview
+    ${previewUrl}
+    
+    Built with commit ${deploymentCommit}.
     This pull request is being automatically deployed with [vercel-action](https://github.com/marketplace/actions/vercel-action)
   `;
 
@@ -225,6 +250,23 @@ async function createCommentOnPullRequest(
       body: commentBody,
     });
   }
+}
+
+async function aliasDomainsToDeployment(deploymentUrl) {
+  if (!deploymentUrl) {
+    core.error('deployment url is null');
+  }
+  const promises = aliasDomains.map(domain => {
+    return exec.exec('npx', [
+      'vercel',
+      'alias',
+      '-t',
+      vercelToken,
+      deploymentUrl,
+      domain,
+    ]);
+  });
+  await Promise.all(promises);
 }
 
 async function run() {
@@ -277,6 +319,11 @@ async function run() {
     core.setOutput('preview-name', deploymentName);
   } else {
     core.warning('get preview-name error');
+  }
+
+  if (aliasDomains.length) {
+    core.info('alias domains to this deployment');
+    await aliasDomainsToDeployment(deploymentUrl);
   }
 
   if (githubComment && githubToken) {

--- a/index.js
+++ b/index.js
@@ -25,9 +25,11 @@ const aliasDomains = core
   .filter(x => x !== '')
   .map(s => {
     let url = s;
-    let branch = context.ref.replace('/', '-');
+    let branch = context.ref.replace('refs/heads/', '').replace(/\//g, '-');
     if (context.eventName === 'pull_request') {
-      branch = context.payload.pull_request.head.ref.replace('/', '-');
+      branch = context.payload.pull_request.head.ref
+        .replace('refs/heads/', '')
+        .replace(/\//g, '-');
       url = url.replace(prNumberRegExp, context.issue.number.toString());
     }
     url = url.replace(branchRegExp, branch);

--- a/index.js
+++ b/index.js
@@ -185,12 +185,21 @@ async function createCommentOnCommit(
     `Deploy preview for _${deploymentName}_ ready!`,
   );
 
+  let previewUrl = deploymentUrl;
+  if (aliasDomains.length) {
+    aliasDomains.forEach(domain => {
+      previewUrl += `\nhttps://${domain}`;
+    });
+  }
+
   const commentBody = stripIndents`
     Deploy preview for _${deploymentName}_ ready!
 
-    Built with commit ${deploymentCommit}
-
-    ${deploymentUrl}
+    ✅ Preview
+    ${previewUrl}
+    
+    Built with commit ${deploymentCommit}.
+    This pull request is being automatically deployed with [vercel-action](https://github.com/marketplace/actions/vercel-action)
   `;
 
   if (commentId) {


### PR DESCRIPTION
New input variable : alias-domains

## Example

```yaml
name: example - angular
on:
  push:
    branches:
      - master
  pull_request:
    branches:
      - master
jobs:
  angular:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - uses: actions/cache@v1
        with:
          path: ~/.npm
          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
          restore-keys: |
            ${{ runner.os }}-node-
      - name: build
        run: |
          cd example/angular
          npm ci
          npx ng build --prod
      - uses: ./
        id: vercel-action-staging
        if: github.event_name == 'pull_request'
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          vercel-token: ${{ secrets.VERCEL_TOKEN }}
          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_ANGULAR }}
          working-directory: example/angular/dist/angular
          alias-domains: |
            staging.angular.vercel-action.amond.dev
            pr-{{PR_NUMBER}}.angular.vercel-action.amond.dev
      - uses: ./
        id: vercel-action-production
        if: github.event_name == 'push'
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          vercel-token: ${{ secrets.VERCEL_TOKEN }}
          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_ANGULAR }}
          working-directory: example/angular/dist/angular
          vercel-args: '--prod '
```

You can use pull request number via `{{PR_NUMBER}}`. 
ex: `https://pr-{{PR_NUMBER}}.angular.vercel-action.amond.dev` => https://pr-18.angular.vercel-action.amond.dev

resolve #7

Signed-off-by: Minsu Lee <amond@amond.net>