### PR TITLE
Fix prod_or_not in example-static

### DIFF
--- a/.github/workflows/example-static.yml
+++ b/.github/workflows/example-static.yml
@@ -28,7 +28,7 @@ jobs:
       - name: production or not
         id: prod_or_not
         run: |
-          if [$REF == 'refs/heads/master']
+          if [ "$REF" == 'refs/heads/master' ]
           then
               echo "::set-output name=vercel-args::--prod"
           else


### PR DESCRIPTION
Currently this step silently fails with

```
✔ production or not
Run if [$REF == 'refs/heads/master']
  if [$REF == 'refs/heads/master']
  then
      echo "::set-output name=vercel-args::--prod"
  else
      echo "::set-output name=vercel-args::"
  fi
  shell: /bin/bash -e {0}
  env:
    VERCEL_ORG_ID: ***
    VERCEL_PROJECT_ID: ***
    REF: refs/pull/36/merge
/home/runner/work/_temp/ef8d826e-e24a-4b54-a019-534ae6281380.sh: line 1: [refs/pull/36/merge: No such file or directory
```