### PR TITLE
feat: Vercel Metadata Override

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1177,6 +1177,21 @@ async function setEnv() {
   }
 }
 
+function addVercelMetadata(key, value, providedArgs) {
+  // returns a list for the metadata commands if key was not supplied by user in action parameters
+  // returns an empty list if key was provided by user
+  const pattern = `^${key}=.+`;
+  const metadataRegex = new RegExp(pattern, 'g');
+  // eslint-disable-next-line no-restricted-syntax
+  for (const arg of providedArgs) {
+    if (arg.match(metadataRegex)) {
+      return [];
+    }
+  }
+
+  return ['-m', `${key}=${value}`];
+}
+
 async function vercelDeploy(ref, commit) {
   let myOutput = '';
   // eslint-disable-next-line no-unused-vars
@@ -1197,30 +1212,29 @@ async function vercelDeploy(ref, commit) {
     options.cwd = workingDirectory;
   }
 
+  const providedArgs = vercelArgs.split(/ +/);
+
   const args = [
     ...vercelArgs.split(/ +/),
-    '-t',
-    vercelToken,
-    '-m',
-    `githubCommitSha=${context.sha}`,
-    '-m',
-    `githubCommitAuthorName=${context.actor}`,
-    '-m',
-    `githubCommitAuthorLogin=${context.actor}`,
-    '-m',
-    'githubDeployment=1',
-    '-m',
-    `githubOrg=${context.repo.owner}`,
-    '-m',
-    `githubRepo=${context.repo.repo}`,
-    '-m',
-    `githubCommitOrg=${context.repo.owner}`,
-    '-m',
-    `githubCommitRepo=${context.repo.repo}`,
-    '-m',
-    `githubCommitMessage=${commit}`,
-    '-m',
-    `githubCommitRef=${ref.replace('refs/heads/', '')}`,
+    ...['-t', vercelToken],
+    ...addVercelMetadata('githubCommitSha', context.sha, providedArgs),
+    ...addVercelMetadata('githubCommitAuthorName', context.actor, providedArgs),
+    ...addVercelMetadata(
+      'githubCommitAuthorLogin',
+      context.actor,
+      providedArgs,
+    ),
+    ...addVercelMetadata('githubDeployment', 1, providedArgs),
+    ...addVercelMetadata('githubOrg', context.repo.owner, providedArgs),
+    ...addVercelMetadata('githubRepo', context.repo.repo, providedArgs),
+    ...addVercelMetadata('githubCommitOrg', context.repo.owner, providedArgs),
+    ...addVercelMetadata('githubCommitRepo', context.repo.repo, providedArgs),
+    ...addVercelMetadata('githubCommitMessage', commit, providedArgs),
+    ...addVercelMetadata(
+      'githubCommitRef',
+      ref.replace('refs/heads/', ''),
+      providedArgs,
+    ),
   ];
 
   if (vercelScope) {

--- a/index.js
+++ b/index.js
@@ -80,6 +80,21 @@ async function setEnv() {
   }
 }
 
+function addVercelMetadata(key, value, providedArgs) {
+  // returns a list for the metadata commands if key was not supplied by user in action parameters
+  // returns an empty list if key was provided by user
+  const pattern = `^${key}=.+`;
+  const metadataRegex = new RegExp(pattern, 'g');
+  // eslint-disable-next-line no-restricted-syntax
+  for (const arg of providedArgs) {
+    if (arg.match(metadataRegex)) {
+      return [];
+    }
+  }
+
+  return ['-m', `${key}=${value}`];
+}
+
 async function vercelDeploy(ref, commit) {
   let myOutput = '';
   // eslint-disable-next-line no-unused-vars
@@ -100,30 +115,29 @@ async function vercelDeploy(ref, commit) {
     options.cwd = workingDirectory;
   }
 
+  const providedArgs = vercelArgs.split(/ +/);
+
   const args = [
     ...vercelArgs.split(/ +/),
-    '-t',
-    vercelToken,
-    '-m',
-    `githubCommitSha=${context.sha}`,
-    '-m',
-    `githubCommitAuthorName=${context.actor}`,
-    '-m',
-    `githubCommitAuthorLogin=${context.actor}`,
-    '-m',
-    'githubDeployment=1',
-    '-m',
-    `githubOrg=${context.repo.owner}`,
-    '-m',
-    `githubRepo=${context.repo.repo}`,
-    '-m',
-    `githubCommitOrg=${context.repo.owner}`,
-    '-m',
-    `githubCommitRepo=${context.repo.repo}`,
-    '-m',
-    `githubCommitMessage=${commit}`,
-    '-m',
-    `githubCommitRef=${ref.replace('refs/heads/', '')}`,
+    ...['-t', vercelToken],
+    ...addVercelMetadata('githubCommitSha', context.sha, providedArgs),
+    ...addVercelMetadata('githubCommitAuthorName', context.actor, providedArgs),
+    ...addVercelMetadata(
+      'githubCommitAuthorLogin',
+      context.actor,
+      providedArgs,
+    ),
+    ...addVercelMetadata('githubDeployment', 1, providedArgs),
+    ...addVercelMetadata('githubOrg', context.repo.owner, providedArgs),
+    ...addVercelMetadata('githubRepo', context.repo.repo, providedArgs),
+    ...addVercelMetadata('githubCommitOrg', context.repo.owner, providedArgs),
+    ...addVercelMetadata('githubCommitRepo', context.repo.repo, providedArgs),
+    ...addVercelMetadata('githubCommitMessage', commit, providedArgs),
+    ...addVercelMetadata(
+      'githubCommitRef',
+      ref.replace('refs/heads/', ''),
+      providedArgs,
+    ),
   ];
 
   if (vercelScope) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "email": "amond@amond.net",
     "url": "https://amond.dev"
   },
-  "version": "20.0.0",
+  "version": "20.0.1",
   "main": "index.js",
   "scripts": {
     "lint": "eslint index.js",


### PR DESCRIPTION
This PR adds the ability to optionally override vercel metadata flags.

Presently, if a metadata tag is supplied to the custom action (githubCommitSha for example); it will be overwritten by what is supplied via the `actions/core` library. I took a minimally invasive approach here by allowing for backwards compatibility without the need for adding additional params to the action call.