### PR TITLE
Fix workflow examples with deprecated commands

### DIFF
--- a/.github/workflows/example-nextjs.yml
+++ b/.github/workflows/example-nextjs.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           if [ "$REF" == 'refs/heads/master' ]
           then
-              echo "::set-output name=vercel-args::--prod --prebuilt"
+              echo "vercel-args=--prod --prebuilt" >> $GITHUB_OUTPUT
           else
-              echo "::set-output name=vercel-args::--prebuilt"
+              echo "vercel-args=--prebuilt" >> $GITHUB_OUTPUT
           fi
         env:
           REF: ${{ github.ref }}

--- a/.github/workflows/example-static.yml
+++ b/.github/workflows/example-static.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           if [ "$REF" == 'refs/heads/master' ]
           then
-              echo "vercel-args=--prod"
+              echo "vercel-args=--prod" >> $GITHUB_OUTPUT
           else
-              echo "vercel-args="
+              echo "vercel-args=" >> $GITHUB_OUTPUT
           fi
         env:
           REF: ${{ github.ref }}

--- a/.github/workflows/example-static.yml
+++ b/.github/workflows/example-static.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           if [ "$REF" == 'refs/heads/master' ]
           then
-              echo "::set-output name=vercel-args::--prod"
+              echo "vercel-args=--prod"
           else
-              echo "::set-output name=vercel-args::"
+              echo "vercel-args="
           fi
         env:
           REF: ${{ github.ref }}


### PR DESCRIPTION
HI there 👋 

Looks like using set-output is throwing some warnings in workflows.

[Ref](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

![image](https://user-images.githubusercontent.com/1702755/198569569-ed2127dc-a9a8-48c8-92c3-d5ba881ba250.png)