### PR TITLE
fix: don't require the deprecated zeit-token action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
     description: 'If you are work in team scope, you should set this value to your team id.'
   zeit-token:
     description: 'zeit.co token'
-    required: true
+    required: false
     deprecationMessage: 'Zeit is now Vercel. Use "vercel-token" instead'
   now-args:
     description: ''


### PR DESCRIPTION
VSCode displays an error:
`Missing required key 'zeit-token'`

![test-and-deploy_yml_—_org-mat-viz](https://user-images.githubusercontent.com/316826/209396982-9e51c929-6695-462e-84a5-116f7455b4f3.jpg)
