### PR TITLE
feat: retry on alias creation error

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function retry(fn, retries) {
         throw error;
       } else {
         core.info(`retrying: attempt ${retry + 1} / ${retries + 1}`);
+        await new Promise(resolve => setTimeout(resolve, 3000));
         return attempt(retry + 1);
       }
     }


### PR DESCRIPTION
We often see `npx vercel alias create` failing intermittently when it creates certificates (we create a new subdomain for each deploy and create an alias to it). Having to re-run the whole deploy because of this is annoying, so this PR introduces retry logic for the `npx vercel alias create` command specifically. 