### PR TITLE
feat: allow spaces in vercel-args

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32636,6 +32636,25 @@ function addVercelMetadata(key, value, providedArgs) {
   return ['-m', `${key}=${value}`];
 }
 
+
+/**
+ * 
+ * The following regex is used to split the vercelArgs string into an array of arguments.
+ * It conserves strings wrapped in double quotes, with nested escaped double quotes, as a single argument.
+ * 
+ * Example:
+ * 
+ * parseArgs('--env foo="bar baz" "foo=\"bar\" baz"') => ['--env', 'foo="bar baz"', 'foo=\\"bar\\" baz']
+ */
+function parseArgs() {
+  const args = [];
+
+  for (const match of vercelArgs.matchAll(/[^\s"]*"[^\\"]*(\\.[^\\"]*)*"|[^\s]+/gm)) {
+    args.push(match[0]);
+  }
+  return args;
+}
+
 async function vercelDeploy(ref, commit) {
   let myOutput = '';
   // eslint-disable-next-line no-unused-vars
@@ -32656,10 +32675,10 @@ async function vercelDeploy(ref, commit) {
     options.cwd = workingDirectory;
   }
 
-  const providedArgs = vercelArgs.split(/ +/);
+  const providedArgs = parseArgs(vercelArgs);
 
   const args = [
-    ...vercelArgs.split(/ +/),
+    ...providedArgs,
     ...['-t', vercelToken],
     ...addVercelMetadata('githubCommitSha', context.sha, providedArgs),
     ...addVercelMetadata('githubCommitAuthorName', context.actor, providedArgs),
@@ -32887,6 +32906,7 @@ async function aliasDomainsToDeployment(deploymentUrl) {
 }
 
 async function run() {
+  core.info('Does it really run ????????????????????????');
   core.debug(`action : ${context.action}`);
   core.debug(`ref : ${context.ref}`);
   core.debug(`eventName : ${context.eventName}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -32640,17 +32640,17 @@ function addVercelMetadata(key, value, providedArgs) {
 /**
  * 
  * The following regex is used to split the vercelArgs string into an array of arguments.
- * It conserves strings wrapped in double quotes, with nested escaped double quotes, as a single argument.
+ * It conserves strings wrapped in simple / double quotes, with nested different quotes, as a single argument.
  * 
  * Example:
  * 
- * parseArgs('--env foo="bar baz" "foo=\"bar\" baz"') => ['--env', 'foo="bar baz"', 'foo=\\"bar\\" baz']
+ * parseArgs(`--env foo=bar "foo=bar baz" 'foo="bar baz"'`) => ['--env', 'foo=bar', 'foo=bar baz', 'foo="bar baz"']
  */
-function parseArgs() {
+function parseArgs(s) {
   const args = [];
 
-  for (const match of vercelArgs.matchAll(/[^\s"]*"[^\\"]*(\\.[^\\"]*)*"|[^\s]+/gm)) {
-    args.push(match[0]);
+  for (const match of s.matchAll(/'([^']*)'|"([^"]*)"|[^\s]+/gm)) {
+    args.push(match[1] ?? match[2] ?? match[0]);
   }
   return args;
 }

--- a/index.js
+++ b/index.js
@@ -123,17 +123,17 @@ function addVercelMetadata(key, value, providedArgs) {
 /**
  * 
  * The following regex is used to split the vercelArgs string into an array of arguments.
- * It conserves strings wrapped in double quotes, with nested escaped double quotes, as a single argument.
+ * It conserves strings wrapped in simple / double quotes, with nested different quotes, as a single argument.
  * 
  * Example:
  * 
- * parseArgs('--env foo="bar baz" "foo=\"bar\" baz"') => ['--env', 'foo="bar baz"', 'foo=\\"bar\\" baz']
+ * parseArgs(`--env foo=bar "foo=bar baz" 'foo="bar baz"'`) => ['--env', 'foo=bar', 'foo=bar baz', 'foo="bar baz"']
  */
-function parseArgs() {
+function parseArgs(s) {
   const args = [];
 
-  for (const match of vercelArgs.matchAll(/[^\s"]*"[^\\"]*(\\.[^\\"]*)*"|[^\s]+/gm)) {
-    args.push(match[0]);
+  for (const match of s.matchAll(/'([^']*)'|"([^"]*)"|[^\s]+/gm)) {
+    args.push(match[1] ?? match[2] ?? match[0]);
   }
   return args;
 }

--- a/index.js
+++ b/index.js
@@ -139,10 +139,10 @@ async function vercelDeploy(ref, commit) {
     options.cwd = workingDirectory;
   }
 
-  const providedArgs = vercelArgs.split(/ +/);
+  const providedArgs = vercelArgs.split(/[^\s"']+|"([^"]*)"|'([^']*)'/);
 
   const args = [
-    ...vercelArgs.split(/ +/),
+    ...vercelArgs.split(/[^\s"']+|"([^"]*)"|'([^']*)'/),
     ...['-t', vercelToken],
     ...addVercelMetadata('githubCommitSha', context.sha, providedArgs),
     ...addVercelMetadata('githubCommitAuthorName', context.actor, providedArgs),

--- a/index.js
+++ b/index.js
@@ -389,7 +389,6 @@ async function aliasDomainsToDeployment(deploymentUrl) {
 }
 
 async function run() {
-  core.info('Does it really run ????????????????????????');
   core.debug(`action : ${context.action}`);
   core.debug(`ref : ${context.ref}`);
   core.debug(`eventName : ${context.eventName}`);

--- a/index.js
+++ b/index.js
@@ -119,6 +119,25 @@ function addVercelMetadata(key, value, providedArgs) {
   return ['-m', `${key}=${value}`];
 }
 
+
+/**
+ * 
+ * The following regex is used to split the vercelArgs string into an array of arguments.
+ * It conserves strings wrapped in double quotes, with nested escaped double quotes, as a single argument.
+ * 
+ * Example:
+ * 
+ * parseArgs('--env foo="bar baz" "foo=\"bar\" baz"') => ['--env', 'foo="bar baz"', 'foo=\\"bar\\" baz']
+ */
+function parseArgs() {
+  const args = [];
+
+  for (const match of vercelArgs.matchAll(/[^\s"]*"[^\\"]*(\\.[^\\"]*)*"|[^\s]+/gm)) {
+    args.push(match[0]);
+  }
+  return args;
+}
+
 async function vercelDeploy(ref, commit) {
   let myOutput = '';
   // eslint-disable-next-line no-unused-vars
@@ -139,10 +158,10 @@ async function vercelDeploy(ref, commit) {
     options.cwd = workingDirectory;
   }
 
-  const providedArgs = vercelArgs.split(/[^\s"']+|"([^"]*)"|'([^']*)'/);
+  const providedArgs = parseArgs(vercelArgs);
 
   const args = [
-    ...vercelArgs.split(/[^\s"']+|"([^"]*)"|'([^']*)'/),
+    ...providedArgs,
     ...['-t', vercelToken],
     ...addVercelMetadata('githubCommitSha', context.sha, providedArgs),
     ...addVercelMetadata('githubCommitAuthorName', context.actor, providedArgs),
@@ -370,6 +389,7 @@ async function aliasDomainsToDeployment(deploymentUrl) {
 }
 
 async function run() {
+  core.info('Does it really run ????????????????????????');
   core.debug(`action : ${context.action}`);
   core.debug(`ref : ${context.ref}`);
   core.debug(`eventName : ${context.eventName}`);


### PR DESCRIPTION
Splitting arguments and preserving the behavior of quotes will finally allow us to use spaces in vercel-args :tada: 

Solve #236 

Thanks for making MORE explicit the necessity to run `npm run package` to rebuild the package, I've wasted hours debugging this....