### PR TITLE
Fix for #249

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ outputs:
   preview-name:
     description: 'deployment preview name'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
(per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)