### PR TITLE
fix: fallback to 41.1.4 instead of 25.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@actions/github": "^2.1.1",
     "axios": "^1.6.8",
     "common-tags": "^1.8.0",
-    "vercel": "25.1.0",
+    "vercel": "41.1.4",
     "@octokit/webhooks": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
I have the issue #266 and after some research I have found out that it was caused by the fallback version of vercel.

https://github.com/amondnet/vercel-action/blob/16e87c0a08142b0d0d33b76aeaf20823c381b9b9/index.js#L58-L63

https://github.com/amondnet/vercel-action/blob/16e87c0a08142b0d0d33b76aeaf20823c381b9b9/package.json#L31
Currently the fallback version of vercel is `25.1.0` and it's a version that being released three years ago. But the latest version of vercel is `41.1.4`. I believe only a few people still using the older version.

![截圖 2025-02-19 19 47 02](https://github.com/user-attachments/assets/f77809fa-e647-4e3c-8558-336af0c30849)

I am not sure if it's best to use latest version of vercel as much as possible by default, and users can still use older version through out using `vercel-version`.


