### PR TITLE
fix: github ref randomly empty for release triggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -424,6 +424,10 @@ async function run() {
       commit = commitData.message;
       core.debug(`The head commit is: ${commit}`);
     }
+  } else if (context.eventName === 'release') {
+    const tagName = context.payload.release.tag_name;
+    ref = `refs/tags/${tagName}`;
+    core.debug(`The release ref is: ${ref}`);
   }
 
   const deploymentUrl = await vercelDeploy(ref, commit);

--- a/index.js
+++ b/index.js
@@ -425,8 +425,8 @@ async function run() {
       core.debug(`The head commit is: ${commit}`);
     }
   } else if (context.eventName === 'release') {
-    const tagName = context.payload.release.tag_name;
-    ref = `refs/tags/${tagName}`;
+    const tagName = context.payload.release?.tag_name;
+    ref = !tagName ? ref : `refs/tags/${tagName}`;
     core.debug(`The release ref is: ${ref}`);
   }
 


### PR DESCRIPTION
Fixes https://github.com/amondnet/vercel-action/issues/46

I believe the cause for the above bug is https://github.com/actions/runner/issues/2788. The workaround to the runner bug is to create the ref yourself by prefixing the tag name with `refs/tags/` (See sources [1](https://github.com/actions/runner/issues/2788#issuecomment-2145922705), [2](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release), [3](https://github.com/orgs/community/discussions/64528#discussioncomment-12978855)).