### PR TITLE
fix: clear VERCEL_ORG_ID and VERCEL_PROJECT_ID env vars on alias retry

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -59631,7 +59631,7 @@ function retry(fn, retries) {
       return await fn()
     }
     catch (error) {
-      if (retry > retries) {
+      if (retry > retries || error.skipRetry) {
         throw error
       }
       else {
@@ -60036,9 +60036,11 @@ async function aliasDomainsToDeployment(deploymentUrl) {
           listeners: {
             stdout: (data) => {
               myOutput += data.toString()
+              core.info(data.toString())
             },
             stderr: (data) => {
               myError += data.toString()
+              core.info(data.toString())
             },
           },
         })
@@ -60050,28 +60052,34 @@ async function aliasDomainsToDeployment(deploymentUrl) {
               'Vercel CLI rejected the scope for alias command. '
               + 'Retrying without --scope.',
             )
-            delete process.env.VERCEL_ORG_ID
-            delete process.env.VERCEL_PROJECT_ID
+            const retryEnv = { ...process.env }
+            delete retryEnv.VERCEL_ORG_ID
+            delete retryEnv.VERCEL_PROJECT_ID
             const retryArgs = [vercelBin, '-t', vercelToken, 'alias', deploymentUrl, domain]
             let retryError = ''
             let retryOutput = ''
             const retryExitCode = await exec.exec('npx', retryArgs, {
               ignoreReturnCode: true,
+              env: retryEnv,
               listeners: {
-                stderr: (data) => {
-                  retryError += data.toString()
-                },
                 stdout: (data) => {
                   retryOutput += data.toString()
+                  core.info(data.toString())
+                },
+                stderr: (data) => {
+                  retryError += data.toString()
+                  core.info(data.toString())
                 },
               },
             })
             if (retryExitCode !== 0) {
               const retryStderr = retryError ? `, stderr: ${retryError.trim()}` : ''
               const retryStdout = retryOutput ? `, stdout: ${retryOutput.trim()}` : ''
-              throw new Error(
+              const error = new Error(
                 `Alias command failed for domain ${domain} with exit code ${retryExitCode}${retryStderr}${retryStdout}`,
               )
+              error.skipRetry = true
+              throw error
             }
             return
           }

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function retry(fn, retries) {
       return await fn()
     }
     catch (error) {
-      if (retry > retries) {
+      if (retry > retries || error.skipRetry) {
         throw error
       }
       else {
@@ -451,9 +451,11 @@ async function aliasDomainsToDeployment(deploymentUrl) {
           listeners: {
             stdout: (data) => {
               myOutput += data.toString()
+              core.info(data.toString())
             },
             stderr: (data) => {
               myError += data.toString()
+              core.info(data.toString())
             },
           },
         })
@@ -465,28 +467,34 @@ async function aliasDomainsToDeployment(deploymentUrl) {
               'Vercel CLI rejected the scope for alias command. '
               + 'Retrying without --scope.',
             )
-            delete process.env.VERCEL_ORG_ID
-            delete process.env.VERCEL_PROJECT_ID
+            const retryEnv = { ...process.env }
+            delete retryEnv.VERCEL_ORG_ID
+            delete retryEnv.VERCEL_PROJECT_ID
             const retryArgs = [vercelBin, '-t', vercelToken, 'alias', deploymentUrl, domain]
             let retryError = ''
             let retryOutput = ''
             const retryExitCode = await exec.exec('npx', retryArgs, {
               ignoreReturnCode: true,
+              env: retryEnv,
               listeners: {
-                stderr: (data) => {
-                  retryError += data.toString()
-                },
                 stdout: (data) => {
                   retryOutput += data.toString()
+                  core.info(data.toString())
+                },
+                stderr: (data) => {
+                  retryError += data.toString()
+                  core.info(data.toString())
                 },
               },
             })
             if (retryExitCode !== 0) {
               const retryStderr = retryError ? `, stderr: ${retryError.trim()}` : ''
               const retryStdout = retryOutput ? `, stdout: ${retryOutput.trim()}` : ''
-              throw new Error(
+              const error = new Error(
                 `Alias command failed for domain ${domain} with exit code ${retryExitCode}${retryStderr}${retryStdout}`,
               )
+              error.skipRetry = true
+              throw error
             }
             return
           }


### PR DESCRIPTION
## Summary

- When retrying the alias command without `--scope` for personal accounts, the Vercel CLI was still reading `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` from the environment and treating them as scope context
- Both env vars are now deleted before the retry, completing the fix started in #310

## Changes

- `index.js`: Delete `process.env.VERCEL_ORG_ID` and `process.env.VERCEL_PROJECT_ID` before alias retry
- `dist/index.js`: Rebuilt bundle reflecting the same change

## Root Cause

The previous fix (#310) removed `--scope` from the CLI arguments, but the Vercel CLI also reads `VERCEL_ORG_ID` from the environment as an implicit scope. Removing only the flag was insufficient; the env vars must also be cleared for the retry to operate without any scope context.

## Test Plan

- [ ] Deploy to a personal Vercel account (no org) with alias domains configured
- [ ] Verify the alias command succeeds on retry without scope-related errors
- [ ] Verify org/project deployments are unaffected (env vars only cleared after first failure)