### PR TITLE
feat(example): add turbopack configuration to nextjs example

### DIFF
--- a/example/nextjs/next.config.js
+++ b/example/nextjs/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  turbopack: {
+    root: '../..',
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary

- Add `turbopack` configuration to `example/nextjs/next.config.js`
- Set `root: '../..'` to point to the monorepo root for proper module resolution when running the Next.js example within the vercel-action workspace

## Test Plan

- [ ] Verify the Next.js example builds successfully with the new Turbopack config
- [ ] Confirm `turbopack` root configuration resolves modules correctly from the monorepo root

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point the Next.js example’s `turbopack` root to `../..` so it resolves monorepo modules and builds correctly in the vercel-action workspace.

<sup>Written for commit 99c78b870197ea04bac11b2e5e36a03d63563412. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

