### PR TITLE
Add git author configuration for CLI deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ This action make a Vercel deployment with github actions.
 | vercel-project-name              | <ul><li>- [ ] </li></ol> |         | The name of the project; if absent we'll use the `vercel inspect` command to determine. [#27](https://github.com/amondnet/vercel-action/issues/27) & [#28](https://github.com/amondnet/vercel-action/issues/28)
 | vercel-version                   | <ul><li>- [x] </li></ol> |         | vercel-cli package version if absent we will use one declared in [package.json](https://github.com/amondnet/vercel-action/blob/master/package.json)
 
+### Git Author Inputs (CLI deployments only)
+
+Vercel's CLI reads the HEAD commit's author when creating a deployment. If your CI runner produces a HEAD commit whose author isn't a Vercel-recognized identity, the deploy can fail or be misattributed. Set both `git-user-email` and `git-user-name` to have the action run `git config` and `git commit --amend --no-edit --reset-author` before deploying. These inputs only take effect when `vercel-args` is provided (CLI path); they are ignored for API-based deployments.
+
+| Name             | Required | Default | Description                                                                          |
+|------------------|:--------:|---------|--------------------------------------------------------------------------------------|
+| git-user-email   |    No    |         | Git `user.email` to set on the HEAD commit before the CLI deploy. Requires `git-user-name`. |
+| git-user-name    |    No    |         | Git `user.name` to set on the HEAD commit before the CLI deploy. Requires `git-user-email`. |
+
+```yaml
+- uses: amondnet/vercel-action@v42
+  with:
+    vercel-token: ${{ secrets.VERCEL_TOKEN }}
+    vercel-org-id: ${{ secrets.ORG_ID }}
+    vercel-project-id: ${{ secrets.PROJECT_ID }}
+    vercel-args: --prod
+    git-user-email: ci-bot@example.com
+    git-user-name: CI Bot
+```
+
+If only one of the two is set, the action logs a warning and skips the rewrite to avoid a half-configured author.
+
 ### API Deployment Inputs (New)
 
 These inputs use the `@vercel/client` API directly instead of the CLI. They are used when `vercel-args` is **not** provided.

--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,14 @@ inputs:
     required: false
     description: 'Retain build cache from previous deployments (default: false).'
     default: 'false'
+  git-user-email:
+    required: false
+    description: 'Git user.email to set on HEAD commit before CLI deploy. When set together with git-user-name, the action runs `git config` and `git commit --amend --no-edit --reset-author` so Vercel attributes the deploy to a recognized identity. CLI deployments only.'
+    default: ''
+  git-user-name:
+    required: false
+    description: Git user.name to set on HEAD commit before CLI deploy. See git-user-email.
+    default: ''
 
 outputs:
   preview-url:

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -46,6 +46,8 @@ describe('getActionConfig', () => {
         'vercel-project-name': 'my-project',
         'vercel-version': '31.0.0',
         'alias-domains': '',
+        'git-user-email': 'k9p3xq@example.test',
+        'git-user-name': 'Mira Halverson',
       }
       return inputs[name] ?? ''
     })
@@ -63,6 +65,8 @@ describe('getActionConfig', () => {
     expect(config.vercelScope).toBe('my-team')
     expect(config.vercelProjectName).toBe('my-project')
     expect(config.vercelBin).toBe('vercel@31.0.0')
+    expect(config.gitUserEmail).toBe('k9p3xq@example.test')
+    expect(config.gitUserName).toBe('Mira Halverson')
   })
 
   it('uses package.json vercel version as fallback', async () => {
@@ -394,6 +398,8 @@ describe('api deployment inputs', () => {
     expect(config.customEnvironment).toBe('')
     expect(config.isPublic).toBe(false)
     expect(config.withCache).toBe(false)
+    expect(config.gitUserEmail).toBe('')
+    expect(config.gitUserName).toBe('')
   })
 
   it('parses production target', async () => {

--- a/src/__tests__/git-config.test.ts
+++ b/src/__tests__/git-config.test.ts
@@ -1,0 +1,107 @@
+import type { ActionConfig } from '../types'
+import { execFileSync } from 'node:child_process'
+import * as core from '@actions/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { configureGitAuthor } from '../git-config'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+vi.mock('@actions/core', () => ({
+  info: vi.fn(),
+  warning: vi.fn(),
+}))
+
+const RANDOM_EMAIL = 'qx7m2k@example.test'
+const RANDOM_NAME = 'Yara Quinlan'
+
+function buildConfig(overrides: Partial<ActionConfig> = {}): ActionConfig {
+  return {
+    vercelArgs: '--prod',
+    gitUserEmail: '',
+    gitUserName: '',
+    ...overrides,
+  } as ActionConfig
+}
+
+describe('configureGitAuthor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('runs git config and amend when both inputs and vercel-args are set', () => {
+    configureGitAuthor(buildConfig({
+      gitUserEmail: RANDOM_EMAIL,
+      gitUserName: RANDOM_NAME,
+    }))
+
+    expect(execFileSync).toHaveBeenCalledTimes(3)
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['config', 'user.email', RANDOM_EMAIL],
+      expect.any(Object),
+    )
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['config', 'user.name', RANDOM_NAME],
+      expect.any(Object),
+    )
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      ['commit', '--amend', '--no-edit', '--reset-author'],
+      expect.any(Object),
+    )
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('skips silently when vercel-args is empty (API path)', () => {
+    configureGitAuthor(buildConfig({
+      vercelArgs: '',
+      gitUserEmail: RANDOM_EMAIL,
+      gitUserName: RANDOM_NAME,
+    }))
+
+    expect(execFileSync).not.toHaveBeenCalled()
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('skips and warns when only git-user-email is set', () => {
+    configureGitAuthor(buildConfig({ gitUserEmail: RANDOM_EMAIL }))
+
+    expect(execFileSync).not.toHaveBeenCalled()
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('git-user-email and git-user-name must be set together'),
+    )
+  })
+
+  it('skips and warns when only git-user-name is set', () => {
+    configureGitAuthor(buildConfig({ gitUserName: RANDOM_NAME }))
+
+    expect(execFileSync).not.toHaveBeenCalled()
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('git-user-email and git-user-name must be set together'),
+    )
+  })
+
+  it('skips silently when both inputs are empty', () => {
+    configureGitAuthor(buildConfig())
+
+    expect(execFileSync).not.toHaveBeenCalled()
+    expect(core.warning).not.toHaveBeenCalled()
+  })
+
+  it('throws a descriptive error when git command fails', () => {
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
+      throw new Error('fatal: not a git repository')
+    })
+
+    expect(() => configureGitAuthor(buildConfig({
+      gitUserEmail: RANDOM_EMAIL,
+      gitUserName: RANDOM_NAME,
+    }))).toThrow(/Failed to configure git author for Vercel deploy: fatal: not a git repository/)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,8 @@ export function getActionConfig(): ActionConfig {
     customEnvironment: core.getInput('custom-environment'),
     isPublic: core.getInput('public') === 'true',
     withCache: core.getInput('with-cache') === 'true',
+    gitUserEmail: core.getInput('git-user-email'),
+    gitUserName: core.getInput('git-user-name'),
   }
 }
 

--- a/src/git-config.ts
+++ b/src/git-config.ts
@@ -1,0 +1,39 @@
+import type { ActionConfig } from './types'
+import { execFileSync } from 'node:child_process'
+import * as core from '@actions/core'
+
+function runGit(args: string[]): void {
+  execFileSync('git', args, { stdio: 'pipe' })
+}
+
+export function configureGitAuthor(config: ActionConfig): void {
+  if (!config.vercelArgs) {
+    return
+  }
+
+  const email = config.gitUserEmail
+  const name = config.gitUserName
+
+  if (!email && !name) {
+    return
+  }
+
+  if (!email || !name) {
+    core.warning(
+      'git-user-email and git-user-name must be set together to rewrite the HEAD commit author. '
+      + 'Skipping git author configuration.',
+    )
+    return
+  }
+
+  core.info('configure git author for vercel cli deploy')
+  try {
+    runGit(['config', 'user.email', email])
+    runGit(['config', 'user.name', name])
+    runGit(['commit', '--amend', '--no-edit', '--reset-author'])
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to configure git author for Vercel deploy: ${message}`)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { createOctokitClient, getActionConfig, setVercelEnv } from './config'
+import { configureGitAuthor } from './git-config'
 import { createCommentOnCommit, createCommentOnPullRequest } from './github-comments'
 import { createGitHubDeployment, updateGitHubDeploymentStatus } from './github-deployment'
 import { isPullRequestType } from './utils'
@@ -249,6 +250,7 @@ async function run(): Promise<void> {
   const octokit = createOctokitClient(config.githubToken)
 
   setVercelEnv(config)
+  configureGitAuthor(config)
 
   const deploymentContext = await getDeploymentContext(octokit)
   const { sha } = deploymentContext

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,8 @@ export interface ActionConfig {
   customEnvironment: string
   isPublic: boolean
   withCache: boolean
+  gitUserEmail: string
+  gitUserName: string
 }
 
 export interface GitHubDeploymentResult {


### PR DESCRIPTION
## Summary
This PR adds support for configuring the git author (user email and name) before Vercel CLI deployments. This ensures that commits created during deployment are attributed to a recognized identity, preventing deployment failures or misattribution when the CI runner's default git author isn't recognized by Vercel.

## Key Changes
- **New module `git-config.ts`**: Implements `configureGitAuthor()` function that:
  - Runs `git config user.email` and `git config user.name` with provided credentials
  - Amends the HEAD commit with `git commit --amend --no-edit --reset-author` to update author metadata
  - Only executes when `vercelArgs` is set (CLI deployments only)
  - Validates that both email and name are provided together, warning if only one is set
  - Provides descriptive error messages if git commands fail

- **Updated `action.yml`**: Added two new optional inputs:
  - `git-user-email`: Git user.email for HEAD commit
  - `git-user-name`: Git user.name for HEAD commit

- **Updated `config.ts`**: Extended `ActionConfig` type and `getActionConfig()` to read the new git author inputs

- **Updated `index.ts`**: Integrated `configureGitAuthor()` call before deployment

- **Updated `types.ts`**: Added `gitUserEmail` and `gitUserName` fields to `ActionConfig` interface

- **Comprehensive test suite**: Added `git-config.test.ts` with 6 test cases covering:
  - Successful git configuration and commit amendment
  - Silent skip when vercelArgs is empty (API path)
  - Warning when only one of email/name is provided
  - Silent skip when both inputs are empty
  - Descriptive error handling for git command failures

## Implementation Details
- The feature is CLI-deployment-only: it silently skips if `vercelArgs` is not provided
- Both `git-user-email` and `git-user-name` must be set together; setting only one triggers a warning and skips execution
- Git commands use `stdio: 'pipe'` to suppress output
- Error messages are wrapped with context about the git author configuration failure
- Updated README with usage examples and detailed explanation of the new inputs

https://claude.ai/code/session_01SoTBUwqCL8dVRkfgnzhKme

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional git author configuration for CLI deployments to ensure Vercel attributes deployments to a recognized identity and avoid CI-related deploy failures. Set `git-user-email` and `git-user-name` to rewrite the HEAD commit author before running the Vercel CLI.

- **New Features**
  - New inputs: `git-user-email`, `git-user-name`. When both are set and `vercel-args` is used, the action runs `git config` and `git commit --amend --no-edit --reset-author`.
  - Safe behavior: no-op for API deployments; warn and skip if only one input is set; clear error messages on git command failures.
  - Implementation: added `configureGitAuthor()` (`git-config.ts`), integrated in `index.ts`, parsed in `config.ts`/`types.ts`, with README docs and tests.

<sup>Written for commit c4f633604c153d9c649f321a96c294390e2f953a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

