### PR TITLE
ci: revert pnpm/action-setup to v5.0.0 (#351)

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: 10.15.0
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.15.0
 
@@ -51,7 +51,7 @@ jobs:
           node-version: 24
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.15.0
 
@@ -74,7 +74,7 @@ jobs:
           node-version: 24
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.15.0
 
@@ -97,7 +97,7 @@ jobs:
           node-version: 24
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.15.0
 
@@ -120,7 +120,7 @@ jobs:
           node-version: 24
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.15.0
 

--- a/.github/workflows/example-angular.yml
+++ b/.github/workflows/example-angular.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.15.0
 

--- a/.github/workflows/example-nextjs.yml
+++ b/.github/workflows/example-nextjs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.15.0
 


### PR DESCRIPTION
## Summary

Reverts `pnpm/action-setup` from v6.0.1 back to v5.0.0 across all workflows. This is **Option A** from issue #351 (recommended path forward).

## Why

v6.0.1 bootstraps via `pnpm@11.0.0-rc.2`. Even after `pnpm self-update` to our pinned `10.15.0`, the active binary retains 11-rc YAML parser behavior and rejects our `lockfileVersion: '9.0'` lockfile:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile ... is broken: expected a single document in the stream, but found more
```

**Evidence the lockfile is fine** (from the issue investigation):
- `pnpm@10.15.0` GA installs cleanly from the same file locally
- No `---` / `...` YAML document markers
- Single occurrence each of `lockfileVersion:`, `settings:`, `importers:`

**Evidence v6.0.1 is the trigger**: jobs pinned to v5.0.0 pre-#347 pass; the v6.0.1-bumped jobs fail. Explicit `version: 10.15.0` input does not override the rc bootstrap.

## Scope

Clean inverse of #347 — 8 line swaps across the same 4 files:

| File | Pins flipped |
|---|---|
| `.github/workflows/ci.yml` | 5 |
| `.github/workflows/check-dist.yml` | 1 |
| `.github/workflows/example-angular.yml` | 1 |
| `.github/workflows/example-nextjs.yml` | 1 |

No changes to `pnpm-lock.yaml`, `package.json`, `dist/`, source code, or `.github/dependabot.yml`.

## Alternatives considered

- **Option B (`standalone: true`)** — principled but unproven; deferred until Dependabot re-proposes a bump, at which point we verify whether v6.0.2+ ships a GA (non-rc) bootstrap first.
- **Option C (regenerate `pnpm-lock.yaml`)** — explicitly not recommended; churns every PR and couples the repo to the action's bundled pnpm.

## Verification

After merge, expect the following to return green on `master` and new PRs:

- [ ] `check-dist` — dist/ parity check runs again
- [ ] `commitlint` (in `ci.yml`)
- [ ] `example-angular`, `example-nextjs`, `example-static`, `example-express-basic-auth`

Core jobs (`Build`, `Lint`, `Test`, `Integration Test`) should remain green (already passing).

## Follow-up

When Dependabot re-proposes the bump, confirm the upstream release ships a GA (non-rc) bootstrap or that `standalone: true` is the documented workaround before adopting.

Closes #351
Reverts #347

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts `pnpm/action-setup` to v5.0.0 across all CI workflows to restore lockfile (v9) compatibility and avoid `ERR_PNPM_BROKEN_LOCKFILE` from v6 bootstrapping `pnpm@11.0.0-rc.2`. Follows issue #351 Option A.

- **Bug Fixes**
  - Pin `pnpm/action-setup` to v5.0.0 and set `version: 10.15.0` in all workflows (including `check-dist.yml`) for deterministic installs.
  - Fix install failures from the 11-rc YAML parser rejecting our lockfile.
  - Updated 4 workflows: `ci.yml`, `check-dist.yml`, `example-angular.yml`, `example-nextjs.yml`.

<sup>Written for commit 57f974b0775fd7092c65e6f8d5705bd6549bd759. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

