### PR TITLE
docs(readme): drop redundant skip-build methods and renumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,40 +139,7 @@ export const config: VercelConfig = {
 
 Since we do the `build` in `github actions`, we don't need to build in `vercel`.
 
-#### Method 1 - via vercel interface
-
-- Specify "Other" as the framework preset, and
-- Enable the Override option for the Build Command, and
-- Leave the Build Command **empty**.
-- This will prevent the build from being attempted and serve your content as-is.
-
-See [docs](https://vercel.com/docs/concepts/deployments/build-step#build-command) for more details
-
-#### Method 2 - via project configuration
-
-You can override the build command in your project configuration to skip Vercel's build step.
-
-**`vercel.ts`** (recommended):
-
-```typescript
-import type { VercelConfig } from '@vercel/config/v1';
-
-export const config: VercelConfig = {
-  buildCommand: '',
-};
-```
-
-**`vercel.json`**:
-
-```json
-{
-  "buildCommand": ""
-}
-```
-
-See [Build Command docs](https://vercel.com/docs/deployments/configure-a-build#build-command) and [Programmatic Configuration](https://vercel.com/docs/project-configuration/vercel-ts) for more details.
-
-#### Method 3 - Prebuilt deployments (recommended)
+#### Method 1 - Prebuilt deployments (recommended)
 
 You can build your project locally (or in GitHub Actions) using `vercel build` and upload only the build artifacts to Vercel — without giving Vercel access to the source code. This uses the [Build Output API](https://vercel.com/docs/build-output-api/v3) specification.
 
@@ -207,9 +174,9 @@ jobs:
 
 See [Vercel's official GitHub Actions example](https://github.com/vercel/examples/tree/main/ci-cd/github-actions) for more details.
 
-#### Method 4 - Build inside the action (`vercel-build`)
+#### Method 2 - Build inside the action (`vercel-build`)
 
-If you want the same prebuilt-deploy benefits as Method 3 but prefer not to manage `vercel pull` / `vercel build` steps yourself, set `vercel-build: true`. The action will run `vercel pull` followed by `vercel build` inside the runner and then upload the resulting `.vercel/output` via the prebuilt path.
+If you want the same prebuilt-deploy benefits as Method 1 but prefer not to manage `vercel pull` / `vercel build` steps yourself, set `vercel-build: true`. The action will run `vercel pull` followed by `vercel build` inside the runner and then upload the resulting `.vercel/output` via the prebuilt path.
 
 This mirrors the [Vercel KB recommended GitHub Actions workflow](https://vercel.com/kb/guide/how-can-i-use-github-actions-with-vercel#configuring-github-actions-for-vercel) but consolidates pull + build + deploy into a single step.
 
@@ -232,7 +199,7 @@ jobs:
 
 Notes:
 
-- `vercel-build` and `prebuilt` are mutually exclusive. Use `prebuilt: true` if you've already produced `.vercel/output` in an earlier step (Method 3); use `vercel-build: true` to let the action run the build for you.
+- `vercel-build` and `prebuilt` are mutually exclusive. Use `prebuilt: true` if you've already produced `.vercel/output` in an earlier step (Method 1); use `vercel-build: true` to let the action run the build for you.
 - Build-time secrets (`build-env`) are forwarded to `vercel build`.
 - The Vercel token is supplied to the CLI via the `VERCEL_TOKEN` environment variable (the documented non-interactive auth path), never as a `--token` argument.
 - When `target: production` is set, the action passes `--environment=production` to `vercel pull` and `--prod` to `vercel build`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ These typed inputs map onto `@vercel/client`'s `DeploymentOptions` and `VercelCl
 |----------------------------|:--------:|-----------|--------------------------------------------------------------------|
 | target                     |    No    | `preview` | Deployment target: `production` or `preview`                       |
 | prebuilt                   |    No    | `false`   | Deploy prebuilt output (requires a prior `vercel build` step). Mutually exclusive with `vercel-build`. |
-| vercel-build               |    No    | `false`   | Run `vercel pull` + `vercel build` inside the action before deploying, then upload `.vercel/output` via the prebuilt path. Mutually exclusive with `prebuilt`. See ["Build inside the action"](#method-4---build-inside-the-action-vercel-build) below. |
+| vercel-build               |    No    | `false`   | Run `vercel pull` + `vercel build` inside the action before deploying, then upload `.vercel/output` via the prebuilt path. Mutually exclusive with `prebuilt`. See ["Build inside the action"](#method-2---build-inside-the-action-vercel-build) below. |
 | vercel-output-dir          |    No    |           | Custom path to prebuilt output. Defaults to `{working-directory}/.vercel/output` |
 | force                      |    No    | `false`   | Force new deployment, bypassing dedupe and build cache             |
 | env                        |    No    |           | Environment variables (`KEY=VALUE` per line)                       |


### PR DESCRIPTION
## Summary

Cleaned up the "Skip vercel's build step" section by removing two methods that were redundant alongside the prebuilt-deployment approach.

## Changes

**Removed:**
- Method 1 - via vercel interface (UI toggle in the Vercel dashboard)
- Method 2 - via project configuration (buildCommand override in vercel.ts / vercel.json)

**Kept and renumbered:**
- Former Method 3 (Prebuilt deployments, recommended) → now **Method 1**
- Former Method 4 (Build inside the action via `vercel-build`) → now **Method 2**

**Updated** two in-section cross-references that referred to "Method 3" → "Method 1".

**Unchanged:** The "Disable Vercel for GitHub" section was intentionally left as-is.

## Rationale

The removed methods required users to configure things in the Vercel UI or override `buildCommand` in project config, but those approaches are superseded by the prebuilt-deployment pattern (now Method 1) which is already documented as the recommended path. Keeping them added noise and created confusion about which method to follow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the README’s “Skip Vercel build step” by removing the UI toggle and project `buildCommand` override, consolidating around prebuilt deployments. Prebuilt deployments are now Method 1, building inside the action with `vercel-build` is Method 2; cross-references were updated and the `vercel-build` input now links to the correct Method 2 anchor.

<sup>Written for commit 75bb8111a2633d69da44d529239693067ea97f89. Summary will update on new commits. <a href="https://cubic.dev/pr/amondnet/vercel-action/pull/366?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

